### PR TITLE
🛡️ Sentinel: Fix timing attack in API key validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Direct string comparison (`===`) was used for checking admin tokens against the configuration.
 **Learning:** Even in high-level languages, timing attacks are possible when comparing secrets. This was missed because the "secure" logic was implemented in one place but not reused consistently.
 **Prevention:** Always use `crypto.timingSafeEqual` (or a wrapper like `secureCompare`) for comparing secrets. Centralize auth logic to avoid inconsistent implementation.
+
+## 2025-02-12 - Timing Attack in API Key Validation
+**Vulnerability:** API key hashes were compared using direct string equality (`===`) in `ApiKeysManager`, exposing a timing attack vulnerability.
+**Learning:** Security utilities like `secureCompare` must be used for ALL secret comparisons, not just passwords. The presence of a "hash" doesn't automatically make `===` safe if the hash is derived from user input and compared to a stored secret.
+**Prevention:** Audit all equality checks involving secrets or hashes of secrets. Enforce usage of `secureCompare`.

--- a/relay/src/tests/api-keys.test.ts
+++ b/relay/src/tests/api-keys.test.ts
@@ -1,0 +1,100 @@
+/**
+ * API Keys Manager Tests
+ *
+ * Tests for API key management and validation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ApiKeysManager, hashApiKey } from "../utils/api-keys";
+import { secureCompare } from "../utils/security";
+
+// Mock GunDB
+const mockGun = {
+  get: vi.fn().mockReturnThis(),
+  map: vi.fn().mockReturnThis(),
+  once: vi.fn(),
+  put: vi.fn(),
+};
+
+const mockRelayUser = {
+  is: { pub: "relay-pub-key" },
+  get: vi.fn().mockReturnThis(),
+  put: vi.fn(),
+};
+
+describe("ApiKeysManager", () => {
+  let manager: ApiKeysManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new ApiKeysManager(mockGun, "relay-pub-key", mockRelayUser);
+  });
+
+  describe("validateApiKey", () => {
+    it("should validate a correct API key", async () => {
+      const token = "shogun-api-1234567890abcdef1234567890abcdef";
+      const tokenHash = hashApiKey(token);
+
+      const mockKeyData = {
+        keyId: "key-123",
+        name: "Test Key",
+        hash: tokenHash,
+        createdAt: Date.now(),
+        expiresAt: null,
+      };
+
+      // Mock finding the key
+      mockGun.once.mockImplementation((cb) => {
+        cb(mockKeyData, "key-123");
+      });
+
+      const result = await manager.validateApiKey(token);
+
+      expect(result).not.toBeNull();
+      expect(result?.keyId).toBe("key-123");
+      expect(result?.name).toBe("Test Key");
+    });
+
+    it("should reject an incorrect API key", async () => {
+      const token = "shogun-api-wrongtoken";
+
+      const mockKeyData = {
+        keyId: "key-123",
+        name: "Test Key",
+        hash: "some-other-hash",
+        createdAt: Date.now(),
+        expiresAt: null,
+      };
+
+      // Mock finding a key with different hash
+      mockGun.once.mockImplementation((cb) => {
+        cb(mockKeyData, "key-123");
+      });
+
+      const result = await manager.validateApiKey(token);
+
+      expect(result).toBeNull();
+    });
+
+    it("should reject an expired API key", async () => {
+      const token = "shogun-api-expired";
+      const tokenHash = hashApiKey(token);
+
+      const mockKeyData = {
+        keyId: "key-expired",
+        name: "Expired Key",
+        hash: tokenHash,
+        createdAt: Date.now() - 100000,
+        expiresAt: Date.now() - 1000, // Expired
+      };
+
+      mockGun.once.mockImplementation((cb) => {
+        cb(mockKeyData, "key-expired");
+      });
+
+      const result = await manager.validateApiKey(token);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/relay/src/utils/api-keys.ts
+++ b/relay/src/utils/api-keys.ts
@@ -7,6 +7,7 @@
 
 import crypto from "crypto";
 import { loggers } from "./logger";
+import { secureCompare } from "./security";
 
 export interface ApiKey {
   keyId: string;
@@ -252,18 +253,19 @@ export class ApiKeysManager {
           keysChecked++;
 
           // Diagnostic: Log each key checked
+          const isMatch = !!(data.hash && secureCompare(data.hash, tokenHash));
           loggers.server.debug(
             {
               keyId,
               dataHash: data.hash?.substring(0, 16) + "...",
               searchHash: hashPreview,
-              matches: data.hash === tokenHash,
+              matches: isMatch,
               keyName: data.name
             },
             `🔑 Checking API key #${keysChecked}`
           );
 
-          if (data.hash === tokenHash) {
+          if (isMatch) {
             // Check expiration
             if (data.expiresAt && Date.now() > data.expiresAt) {
               loggers.server.debug({ keyId: data.keyId }, "API key expired");


### PR DESCRIPTION
🛡️ Severity: MEDIUM
💡 Vulnerability: API key hashes were compared using direct string equality (`===`) in `ApiKeysManager`. This is susceptible to timing attacks, where an attacker could theoretically deduce the hash by measuring response times.
🎯 Impact: While difficult to exploit due to network latency and the fact that it's a hash comparison (not the secret itself), it violates security best practices and could potentially aid in a brute-force attack.
🔧 Fix: Replaced `===` with `secureCompare` from `relay/src/utils/security.ts`, which uses `crypto.timingSafeEqual` for constant-time comparison.
✅ Verification: Added a new test suite `relay/src/tests/api-keys.test.ts` to verify API key validation works correctly with `secureCompare`. All existing tests passed.
PROCESS:
- Added journal entry to `.jules/sentinel.md`.
- Verified with unit tests.

---
*PR created automatically by Jules for task [18384132396666534075](https://jules.google.com/task/18384132396666534075) started by @scobru*