### PR TITLE
🎨 Palette: Add "Copied!" feedback to API Key copy button

### DIFF
--- a/relay/src/public/dashboard/src/views/ApiKeys.tsx
+++ b/relay/src/public/dashboard/src/views/ApiKeys.tsx
@@ -15,6 +15,7 @@ function ApiKeys() {
   const [newExpires, setNewExpires] = useState('')
   const [createdToken, setCreatedToken] = useState('')
   const [status, setStatus] = useState('')
+  const [copied, setCopied] = useState(false)
 
   const loadKeys = useCallback(async () => {
     try {
@@ -103,7 +104,16 @@ function ApiKeys() {
             <code className="bg-base-300 p-2 rounded block mt-2 text-xs break-all">{createdToken}</code>
           </div>
           <div className="flex gap-2">
-            <button className="btn btn-sm" onClick={() => navigator.clipboard.writeText(createdToken)}>📋 Copy</button>
+            <button
+              className="btn btn-sm"
+              onClick={() => {
+                navigator.clipboard.writeText(createdToken)
+                setCopied(true)
+                setTimeout(() => setCopied(false), 2000)
+              }}
+            >
+              {copied ? '✅ Copied!' : '📋 Copy'}
+            </button>
             <button className="btn btn-sm btn-primary" onClick={() => setCreatedToken('')}>Done</button>
           </div>
         </div>


### PR DESCRIPTION
💡 What: Added a "Copied!" state to the API Key copy button.
🎯 Why: Users need immediate feedback when they copy a key to confirm the action was successful.
📸 Before/After: Button now changes from "📋 Copy" to "✅ Copied!" for 2 seconds.
♿ Accessibility: The button label updates to reflect the action status, providing confirmation to all users.

---
*PR created automatically by Jules for task [15789648435528261017](https://jules.google.com/task/15789648435528261017) started by @scobru*