### PR TITLE
🛡️ Sentinel: Fix unprotected debug endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** Direct string comparison (`===`) was used for validating admin tokens in multiple route handlers (`uploads.ts`, `x402.ts`, `network.ts`, `chat.ts`), exposing the application to timing attacks.
 **Learning:** Security fixes must be applied systematically. A helper function `validateAdminToken` was created to centralize and enforce secure comparison, preventing future regressions and code duplication.
 **Prevention:** Use `validateAdminToken` from `relay/src/utils/auth-utils.ts` for all admin authentication checks. Avoid ad-hoc comparisons of sensitive tokens.
+
+## 2025-05-15 - Unprotected Debug Endpoints
+**Vulnerability:** Critical debug endpoints (including data reset and sensitive data exposure) were mounted publicly without authentication.
+**Learning:** The `debug.ts` router was imported and used in `index.ts` without any middleware applied at the mount point or within the router file itself, despite having sensitive operations like `reset`.
+**Prevention:** Always apply authentication middleware at the router level (using `router.use()`) for any router file containing administrative or debug functions, or verify that the mounting point in `index.ts` applies the middleware.

--- a/relay/src/routes/debug.ts
+++ b/relay/src/routes/debug.ts
@@ -1,8 +1,12 @@
 import express, { Request, Response, Router } from "express";
 import { loggers } from "../utils/logger";
 import { GUN_PATHS } from "../utils/gun-paths";
+import { adminAuthMiddleware } from "../middleware/admin-auth";
 
 const router: Router = express.Router();
+
+// Apply admin authentication to all debug routes
+router.use(adminAuthMiddleware);
 
 // Middleware per ottenere l'istanza Gun dal relay
 const getGunInstance = (req: Request): any => {

--- a/relay/src/tests/debug-routes-security.test.ts
+++ b/relay/src/tests/debug-routes-security.test.ts
@@ -1,0 +1,58 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks must be hoisted or defined before imports if using vi.mock factory
+const mockRouter = {
+  get: vi.fn(),
+  post: vi.fn(),
+  use: vi.fn(),
+};
+
+vi.mock('express', () => ({
+  default: {
+    Router: () => mockRouter,
+  },
+}));
+
+vi.mock('../utils/logger', () => ({
+  loggers: {
+    server: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../utils/gun-paths', () => ({
+  GUN_PATHS: {
+    MB_USAGE: 'mb-usage',
+    UPLOADS: 'uploads',
+    TEST: 'test',
+  },
+}));
+
+// Mock the middleware module
+vi.mock('../middleware/admin-auth', () => ({
+  adminAuthMiddleware: vi.fn(),
+}));
+
+describe('Debug Routes Security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should apply adminAuthMiddleware to all routes', async () => {
+    // Import the middleware to get the mock reference
+    const { adminAuthMiddleware } = await import('../middleware/admin-auth');
+
+    // Import the router (this executes the code in debug.ts)
+    await import('../routes/debug');
+
+    // Check if router.use was called with the middleware
+    // If this fails, it means the routes are unprotected!
+    expect(mockRouter.use).toHaveBeenCalledWith(adminAuthMiddleware);
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix unprotected debug endpoints

**Vulnerability:**
The `relay/src/routes/debug.ts` module exposed sensitive endpoints without any authentication, including:
- `POST /user-mb-usage/:identifier/reset`: Allows resetting a user's MB usage (quota bypass).
- `GET /user-uploads/:identifier`: Exposes user upload metadata and file hashes.
- `GET /mb-usage/:userAddress`: Exposes user usage data.
- `GET /test-gun`: Allows writing arbitrary test data to GunDB.

**Impact:**
An attacker could reset their usage limits to bypass quotas or inspect other users' upload metadata.

**Fix:**
Applied `adminAuthMiddleware` to the entire `debugRouter` using `router.use()`. This ensures all routes defined in `debug.ts` require a valid admin token.

**Verification:**
Added `relay/src/tests/debug-routes-security.test.ts` which mocks Express and verifies that `router.use` is called with the `adminAuthMiddleware`. Run with `npm test` inside `relay/`.


---
*PR created automatically by Jules for task [12925518622604187663](https://jules.google.com/task/12925518622604187663) started by @scobru*