### PR TITLE
🎨 Palette: Standardize Copy Feedback

### DIFF
--- a/relay/src/public/dashboard/src/components/CopyButton.tsx
+++ b/relay/src/public/dashboard/src/components/CopyButton.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+
+interface CopyButtonProps {
+  textToCopy: string
+  label?: string
+  className?: string
+  children?: React.ReactNode
+  successContent?: React.ReactNode
+}
+
+export function CopyButton({
+  textToCopy,
+  label = 'Copy',
+  className = '',
+  children = '📋',
+  successContent = '✅'
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    try {
+      await navigator.clipboard.writeText(textToCopy)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+    }
+  }
+
+  return (
+    <button
+      className={className}
+      onClick={handleCopy}
+      title={label}
+      aria-label={label}
+      type="button"
+    >
+      {copied ? successContent : children}
+    </button>
+  )
+}

--- a/relay/src/public/dashboard/src/views/ApiKeys.tsx
+++ b/relay/src/public/dashboard/src/views/ApiKeys.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useAuth } from '../context/AuthContext'
+import { CopyButton } from '../components/CopyButton'
 
 interface ApiKey {
   keyId: string; name: string; createdAt: number; lastUsedAt?: number; expiresAt?: number
@@ -15,7 +16,6 @@ function ApiKeys() {
   const [newExpires, setNewExpires] = useState('')
   const [createdToken, setCreatedToken] = useState('')
   const [status, setStatus] = useState('')
-  const [copied, setCopied] = useState(false)
 
   const loadKeys = useCallback(async () => {
     try {
@@ -104,16 +104,13 @@ function ApiKeys() {
             <code className="bg-base-300 p-2 rounded block mt-2 text-xs break-all">{createdToken}</code>
           </div>
           <div className="flex gap-2">
-            <button
+            <CopyButton
+              textToCopy={createdToken}
               className="btn btn-sm"
-              onClick={() => {
-                navigator.clipboard.writeText(createdToken)
-                setCopied(true)
-                setTimeout(() => setCopied(false), 2000)
-              }}
+              successContent="✅ Copied!"
             >
-              {copied ? '✅ Copied!' : '📋 Copy'}
-            </button>
+              📋 Copy
+            </CopyButton>
             <button className="btn btn-sm btn-primary" onClick={() => setCreatedToken('')}>Done</button>
           </div>
         </div>

--- a/relay/src/public/dashboard/src/views/Files.tsx
+++ b/relay/src/public/dashboard/src/views/Files.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useAuth } from '../context/AuthContext'
+import { CopyButton } from '../components/CopyButton'
 
 
 interface Pin {
@@ -474,11 +475,7 @@ function Files() {
                     </div>
                     <div className="card-actions justify-end mt-2">
                       <button className="btn btn-ghost btn-xs" onClick={() => handlePreview(pin)} title="Preview" aria-label={`Preview ${pin.name}`}>👁️</button>
-                      <button className="btn btn-ghost btn-xs" onClick={() => {
-                        navigator.clipboard.writeText(pin.cid)
-                        setStatusMessage('CID Copied!')
-                        setTimeout(() => setStatusMessage(''), 2000)
-                      }} title="Copy CID" aria-label={`Copy CID for ${pin.name}`}>📋</button>
+                      <CopyButton textToCopy={pin.cid} className="btn btn-ghost btn-xs" label={`Copy CID for ${pin.name}`} />
                       <button className="btn btn-ghost btn-xs text-error" onClick={() => handleRemove(pin.cid)} title="Delete" aria-label={`Delete ${pin.name}`}>🗑️</button>
                     </div>
                   </div>
@@ -514,7 +511,10 @@ function Files() {
               )}
             </div>
             
-            <div className="mt-4 text-xs text-base-content/60 font-mono">CID: {preview.cid}</div>
+            <div className="mt-4 text-xs text-base-content/60 font-mono flex items-center gap-2">
+              CID: {preview.cid}
+              <CopyButton textToCopy={preview.cid} className="btn btn-ghost btn-xs" label="Copy CID" />
+            </div>
           </div>
           <form method="dialog" className="modal-backdrop">
             <button onClick={closePreview}>close</button>

--- a/relay/src/public/dashboard/src/views/Torrents.tsx
+++ b/relay/src/public/dashboard/src/views/Torrents.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '../context/AuthContext'
+import { CopyButton } from '../components/CopyButton'
 
 
 interface Torrent {
@@ -544,7 +545,13 @@ function Torrents() {
 
                         {/* Actions */}
                         <div className="flex gap-2 justify-end mt-2">
-                            <button className="btn btn-xs btn-outline" onClick={() => {navigator.clipboard.writeText(t.magnetURI || ''); setStatusMsg('Magnet copied!')}}>🧲 Magnet</button>
+                            <CopyButton
+                                textToCopy={t.magnetURI || ''}
+                                className="btn btn-xs btn-outline"
+                                successContent="✅ Copied!"
+                            >
+                                🧲 Magnet
+                            </CopyButton>
                             {t.state === 'paused' ? (
                             <button className="btn btn-xs btn-success" onClick={() => handleAction(t.infoHash, 'resume')}>▶ Resume</button>
                             ) : (
@@ -715,11 +722,17 @@ function Torrents() {
                                 >
                                     ➕ Add
                                 </button>
-                                <button 
-                                    className="btn btn-xs btn-ghost" 
-                                    onClick={() => navigator.clipboard.writeText(res.magnet || res.torrentUrl || '')}
-                                    disabled={!res.magnet && !res.torrentUrl}
-                                >📋 Copy</button>
+                                { (res.magnet || res.torrentUrl) ? (
+                                    <CopyButton
+                                        textToCopy={res.magnet || res.torrentUrl || ''}
+                                        className="btn btn-xs btn-ghost"
+                                        successContent="✅ Copied"
+                                    >
+                                        📋 Copy
+                                    </CopyButton>
+                                ) : (
+                                    <button className="btn btn-xs btn-ghost" disabled>📋 Copy</button>
+                                )}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Added a reusable `CopyButton` component that provides immediate visual feedback (✅) when clicked. Updated Files, Torrents, and ApiKeys views to use it.
🎯 Why: Users previously had inconsistent or invisible feedback when copying CIDs or keys. This improves confidence and accessibility.
📸 Before/After: Replaced manual clipboard logic with a standardized button component.
♿ Accessibility: Added proper aria-labels and visual state changes.

---
*PR created automatically by Jules for task [13586454770712698222](https://jules.google.com/task/13586454770712698222) started by @scobru*