### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to auth endpoints

### DIFF
--- a/relay/src/middleware/rate-limit.ts
+++ b/relay/src/middleware/rate-limit.ts
@@ -1,0 +1,20 @@
+import { rateLimit } from "express-rate-limit";
+import { loggers } from "../utils/logger";
+
+/**
+ * Rate limiter for authentication endpoints
+ * Prevents brute force attacks and DoS
+ */
+export const authRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 20, // Limit each IP to 20 requests per `window` (here, per 15 minutes)
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  handler: (req, res) => {
+    loggers.server.warn({ ip: req.ip }, "Rate limit exceeded for auth endpoint");
+    res.status(429).json({
+      success: false,
+      error: "Too many authentication attempts, please try again later.",
+    });
+  },
+});

--- a/relay/src/routes/auth.ts
+++ b/relay/src/routes/auth.ts
@@ -1,6 +1,7 @@
 
 import express, { Request, Response } from "express";
 import { loggers } from "../utils/logger";
+import { authRateLimiter } from "../middleware/rate-limit";
 
 const router = express.Router();
 
@@ -13,7 +14,7 @@ const getGun = (req: Request) => {
  * POST /api/v1/auth/register
  * Create a new GunDB user on the Relay
  */
-router.post("/register", async (req: Request, res: Response) => {
+router.post("/register", authRateLimiter, async (req: Request, res: Response) => {
   try {
     const { username, password } = req.body;
 
@@ -77,7 +78,7 @@ router.post("/register", async (req: Request, res: Response) => {
  * POST /api/v1/auth/login
  * Authenticate a GunDB user on the Relay
  */
-router.post("/login", async (req: Request, res: Response) => {
+router.post("/login", authRateLimiter, async (req: Request, res: Response) => {
     try {
       const { username, password } = req.body;
   


### PR DESCRIPTION
Added rate limiting to `/api/v1/auth/register` and `/api/v1/auth/login` endpoints to prevent brute-force attacks and DoS attempts. Configured to allow 20 requests per 15 minutes per IP address. Used `express-rate-limit` middleware. Verified that `trust proxy` is enabled in the application configuration to ensure correct IP detection behind proxies.

---
*PR created automatically by Jules for task [7616017594926650675](https://jules.google.com/task/7616017594926650675) started by @scobru*