### PR TITLE
Fix "Invalid amount" error on Registry Unstake action

### DIFF
--- a/relay/src/public/dashboard/src/views/Registry.tsx
+++ b/relay/src/public/dashboard/src/views/Registry.tsx
@@ -185,7 +185,7 @@ function Registry() {
   };
 
   const handleStakingAction = async () => {
-    if (!stakeActionAmount || parseFloat(stakeActionAmount) <= 0) {
+    if (stakingMode === "increase" && (!stakeActionAmount || parseFloat(stakeActionAmount) <= 0)) {
       setActionStatus("❌ Invalid amount");
       return;
     }


### PR DESCRIPTION
Fixed a bug in the Registry dashboard where clicking "Unstake" would trigger an "Invalid amount" error because the validation logic incorrectly enforced a positive amount even for actions that don't require input.
The fix restricts the amount validation to only the "increase" staking mode.
Verified with a Playwright script that intercepted the API call and confirmed the action proceeds correctly.

---
*PR created automatically by Jules for task [2393916251042244879](https://jules.google.com/task/2393916251042244879) started by @scobru*