### PR TITLE
🎨 Palette: Add ARIA labels to dashboard header buttons

### DIFF
--- a/relay/src/public/dashboard/src/components/Header.tsx
+++ b/relay/src/public/dashboard/src/components/Header.tsx
@@ -25,7 +25,7 @@ function Header() {
     <header className="navbar bg-base-100 border-b border-base-300 px-4 gap-2">
       {/* Mobile menu button */}
       <div className="flex-none lg:hidden">
-        <label htmlFor="main-drawer" className="btn btn-square btn-ghost">
+        <label htmlFor="main-drawer" aria-label="Open sidebar" className="btn btn-square btn-ghost">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="inline-block w-5 h-5 stroke-current">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"></path>
           </svg>
@@ -51,7 +51,8 @@ function Header() {
         {/* Theme toggle */}
         <label className="swap swap-rotate btn btn-ghost btn-circle">
           <input 
-            type="checkbox" 
+            type="checkbox"
+            aria-label="Toggle theme"
             className="theme-controller" 
             checked={theme === 'dark'}
             onChange={toggleTheme}
@@ -70,6 +71,7 @@ function Header() {
             className="btn btn-ghost btn-circle"
             onClick={logout} 
             title="Logout"
+            aria-label="Logout"
           >
             🔓
           </button>

--- a/relay/src/public/dashboard/vite.config.ts
+++ b/relay/src/public/dashboard/vite.config.ts
@@ -4,6 +4,9 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    global: 'window',
+  },
   base: '/dashboard/',
   server: {
     proxy: {


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the mobile menu button, theme toggle, and logout button in the Dashboard Header. Also added `define: { global: 'window' }` to `vite.config.ts` to fix a runtime error caused by GunDB dependency.
🎯 Why: To improve accessibility for screen readers and ensure the dashboard loads correctly.
📸 Before/After: Visuals are unchanged, but controls are now announced correctly by screen readers.
♿ Accessibility: Icon-only buttons now have descriptive labels.

---
*PR created automatically by Jules for task [7677924692038422474](https://jules.google.com/task/7677924692038422474) started by @scobru*