### PR TITLE
🎨 Palette: Improve Drive interactions (Copy feedback & Error handling)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-21 - [Modal Error Handling]
+**Learning:** The project frequently uses native `alert()` for errors, which disrupts user flow. DaisyUI `alert` component inside modals provides a much smoother, non-blocking experience.
+**Action:** Replace `alert()` with inline `alert-error` components within modal state for future error handling improvements.


### PR DESCRIPTION
This PR improves the UX of the Drive view in the dashboard.
It addresses the lack of feedback when copying public links and replaces jarring native `alert()` calls with inline error messages in modals.

Changes:
- Added `linkCopied` state to `Drive` component to manage copy feedback.
- Updated `Link Modal` to show a success state on the copy button for 2 seconds after clicking.
- Updated `Rename Modal` and `Link Modal` to display errors inline using DaisyUI alerts instead of `window.alert()`.
- Added `aria-label` to the copy button.

Verified with Playwright script (screenshots attached in verification step).

---
*PR created automatically by Jules for task [3440392729037520479](https://jules.google.com/task/3440392729037520479) started by @scobru*