### PR TITLE
Palette: Add copy feedback to API Key creation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-21 - [Modal Error Handling]
 **Learning:** The project frequently uses native `alert()` for errors, which disrupts user flow. DaisyUI `alert` component inside modals provides a much smoother, non-blocking experience.
 **Action:** Replace `alert()` with inline `alert-error` components within modal state for future error handling improvements.
+
+## 2025-02-24 - [Copy Button Feedback Pattern]
+**Learning:** Dashboard users need immediate confirmation when copying sensitive data (like API keys). The established pattern is to toggle button state to `btn-success` with a checkmark icon for 2 seconds.
+**Action:** Always implement local `copied` state for copy buttons to provide consistent visual feedback.

--- a/relay/src/public/dashboard/src/views/ApiKeys.tsx
+++ b/relay/src/public/dashboard/src/views/ApiKeys.tsx
@@ -13,6 +13,7 @@ function ApiKeys() {
   const [newName, setNewName] = useState('')
   const [newExpires, setNewExpires] = useState('')
   const [createdToken, setCreatedToken] = useState('')
+  const [copied, setCopied] = useState(false)
   const [status, setStatus] = useState('')
 
   const loadKeys = useCallback(async () => {
@@ -98,7 +99,16 @@ function ApiKeys() {
             <code className="bg-base-300 p-2 rounded block mt-2 text-xs break-all">{createdToken}</code>
           </div>
           <div className="flex gap-2">
-            <button className="btn btn-sm" onClick={() => navigator.clipboard.writeText(createdToken)}>📋 Copy</button>
+            <button
+              className={`btn btn-sm ${copied ? 'btn-success text-white' : ''}`}
+              onClick={() => {
+                navigator.clipboard.writeText(createdToken)
+                setCopied(true)
+                setTimeout(() => setCopied(false), 2000)
+              }}
+            >
+              {copied ? '✅ Copied!' : '📋 Copy'}
+            </button>
             <button className="btn btn-sm btn-primary" onClick={() => setCreatedToken('')}>Done</button>
           </div>
         </div>


### PR DESCRIPTION
💡 What: Added visual feedback to the API Key copy button.
🎯 Why: Users need confirmation that the sensitive token was copied successfully.
📸 Before/After: The button now changes to "✅ Copied!" (green) for 2 seconds.
♿ Accessibility: Updated button text provides feedback for screen readers as well.

---
*PR created automatically by Jules for task [10702567203016048226](https://jules.google.com/task/10702567203016048226) started by @scobru*