### PR TITLE
feat(dashboard): replace proofs with storage/pins in reputation leaderboard

### DIFF
--- a/relay/src/public/dashboard/src/views/Network.tsx
+++ b/relay/src/public/dashboard/src/views/Network.tsx
@@ -13,8 +13,8 @@ interface ReputationEntry {
   host: string;
   calculatedScore?: { total: number };
   uptimePercent?: number;
-  proofsSuccessful?: number;
-  proofsTotal?: number;
+  storageUsedMB?: number;
+  ipfsPinsCount?: number;
 }
 
 interface GunPeerEntry {
@@ -280,7 +280,8 @@ function Network() {
                     <th>Score</th>
                     <th>Tier</th>
                     <th>Uptime</th>
-                    <th>Proofs</th>
+                    <th>Storage</th>
+                    <th>Pins</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -306,7 +307,10 @@ function Network() {
                         </td>
                         <td>{(relay.uptimePercent || 0).toFixed(1)}%</td>
                         <td>
-                          {relay.proofsSuccessful || 0}/{relay.proofsTotal || 0}
+                          {(relay.storageUsedMB || 0).toFixed(0)} MB
+                        </td>
+                        <td>
+                          {relay.ipfsPinsCount || 0}
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
- Update `ReputationEntry` interface to include `storageUsedMB` and `ipfsPinsCount`
- Remove deprecated `proofsSuccessful` and `proofsTotal` from leaderboard
- Add "Storage" and "Pins" columns to the Reputation Leaderboard
- This aligns the leaderboard with the Network Overview metrics

---
*PR created automatically by Jules for task [15735096230404839388](https://jules.google.com/task/15735096230404839388) started by @scobru*