### PR TITLE
⚡ Bolt: optimize frontend file and folder uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-27 - Parallelizing I/O in Storage Adapter
 **Learning:** `FsStorageAdapter.getStorageStats` was using a sequential `for...of` loop for recursive directory traversal, which is an anti-pattern for I/O-bound operations. Even though `listDirectory` was optimized, this method was missed.
 **Action:** Audit all recursive file system operations for sequential loops and refactor to use `Promise.all` to leverage Node.js non-blocking I/O.
+
+## 2025-05-27 - Parallelizing Network Requests in Frontend
+**Learning:** Even if the backend storage adapter correctly handles I/O concurrently, sequential network requests from the frontend (e.g. `for (const file of files) await fetch(...)` for uploads) become a severe bottleneck for large operations like directory uploads.
+**Action:** Use chunked `Promise.all` (e.g., chunks of 5) for multi-file operations in the frontend to parallelize network transfers without exceeding browser connection limits or overwhelming the backend server.

--- a/relay/src/public/dashboard/src/views/Drive.tsx
+++ b/relay/src/public/dashboard/src/views/Drive.tsx
@@ -39,7 +39,29 @@ function Drive() {
   const downloadFile = async (filePath: string) => { try { const res = await fetch(`/api/v1/drive/download/${encodeURIComponent(filePath)}`, { headers: getAuthHeaders() }); if (!res.ok) throw new Error('Download failed'); const blob = await res.blob(); const url = window.URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = filePath.split('/').pop() || 'file'; document.body.appendChild(a); a.click(); document.body.removeChild(a); window.URL.revokeObjectURL(url) } catch {} }
   const deleteItem = async (itemPath: string) => { if (!confirm(`Delete "${itemPath.split('/').pop()}"?`)) return; try { const res = await fetch(`/api/v1/drive/delete/${encodeURIComponent(itemPath)}`, { method: 'DELETE', headers: getAuthHeaders() }); const data = await res.json(); if (data.success) { loadFiles(); loadStats() } } catch {} }
   const createFolder = async () => { if (!newFolderName.trim()) return; try { const path = currentPath ? `${currentPath}/${newFolderName}` : newFolderName; const res = await fetch('/api/v1/drive/mkdir', { method: 'POST', headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' }, body: JSON.stringify({ path }) }); const data = await res.json(); if (data.success) { setShowFolderModal(false); setNewFolderName(''); loadFiles(); loadStats() } } catch {} }
-  const uploadFiles = async () => { if (selectedFiles.length === 0) return; setUploading(true); try { for (const file of selectedFiles) { const formData = new FormData(); formData.append('file', file); if (currentPath) formData.append('path', currentPath); await fetch('/api/v1/drive/upload', { method: 'POST', headers: getAuthHeaders(), body: formData }) }; setShowUploadModal(false); setSelectedFiles([]); loadFiles(); loadStats() } catch {} finally { setUploading(false) } }
+  const uploadFiles = async () => {
+    if (selectedFiles.length === 0) return;
+    setUploading(true);
+    try {
+      // ⚡ Bolt: Use chunked parallel uploads to speed up multi-file transfers without overwhelming browser/server
+      const CHUNK_SIZE = 5;
+      for (let i = 0; i < selectedFiles.length; i += CHUNK_SIZE) {
+        const chunk = selectedFiles.slice(i, i + CHUNK_SIZE);
+        await Promise.all(chunk.map(async (file) => {
+          const formData = new FormData();
+          formData.append('file', file);
+          if (currentPath) formData.append('path', currentPath);
+          return fetch('/api/v1/drive/upload', { method: 'POST', headers: getAuthHeaders(), body: formData });
+        }));
+      }
+      setShowUploadModal(false);
+      setSelectedFiles([]);
+      loadFiles();
+      loadStats();
+    } catch {} finally {
+      setUploading(false);
+    }
+  }
   const getBreadcrumbs = () => { const parts = currentPath.split('/').filter((p: string) => p); const crumbs = [{ name: 'Home', path: '' }]; let path = ''; parts.forEach((part: string) => { path += (path ? '/' : '') + part; crumbs.push({ name: part, path }) }); return crumbs }
 
   const handleRename = async () => {
@@ -97,21 +119,26 @@ function Drive() {
     if (files.length === 0) return
     setUploading(true)
     try {
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i]
-        // @ts-ignore - webkitRelativePath is available for folder uploads
-        const relativePath = file.webkitRelativePath || file.name
-        const fullPath = currentPath ? `${currentPath}/${relativePath}` : relativePath
-        
-        const formData = new FormData()
-        formData.append('file', file)
-        formData.append('path', fullPath.split('/').slice(0, -1).join('/')) // Directory path
-        
-        await fetch('/api/v1/drive/upload', {
-          method: 'POST',
-          headers: getAuthHeaders(),
-          body: formData
-        })
+      // ⚡ Bolt: Use chunked parallel uploads for folders to dramatically speed up deep directory structures
+      const CHUNK_SIZE = 5;
+      const fileArray = Array.from(files);
+      for (let i = 0; i < fileArray.length; i += CHUNK_SIZE) {
+        const chunk = fileArray.slice(i, i + CHUNK_SIZE);
+        await Promise.all(chunk.map(async (file) => {
+          // @ts-ignore - webkitRelativePath is available for folder uploads
+          const relativePath = file.webkitRelativePath || file.name
+          const fullPath = currentPath ? `${currentPath}/${relativePath}` : relativePath
+
+          const formData = new FormData()
+          formData.append('file', file)
+          formData.append('path', fullPath.split('/').slice(0, -1).join('/')) // Directory path
+
+          return fetch('/api/v1/drive/upload', {
+            method: 'POST',
+            headers: getAuthHeaders(),
+            body: formData
+          })
+        }));
       }
       loadFiles()
       loadStats()


### PR DESCRIPTION
💡 What: Refactored `uploadFiles` and `uploadFolder` in `Drive.tsx` to use a chunked `Promise.all` strategy (batching 5 concurrent requests) instead of awaiting sequential `fetch` calls in a `for...of` loop.
🎯 Why: Sequential file uploads from the frontend are a severe bottleneck for large directory structures.
📊 Impact: Significantly speeds up multi-file and directory uploads by parallelizing the network I/O, while the chunking prevents maxing out the browser's concurrent connection limit per origin and protects the server from being overwhelmed.
🔬 Measurement: Verify by uploading a directory with many files. The upload will complete noticeably faster, and network dev tools will show up to 5 concurrent upload requests processing simultaneously.

---
*PR created automatically by Jules for task [17484845611904099906](https://jules.google.com/task/17484845611904099906) started by @scobru*