### PR TITLE
🎨 Palette: Add aria-label to Admin Password input

### DIFF
--- a/relay/src/public/dashboard/src/views/Settings.tsx
+++ b/relay/src/public/dashboard/src/views/Settings.tsx
@@ -271,6 +271,7 @@ function Settings() {
                   type="password"
                   className="input input-bordered join-item flex-1"
                   placeholder="Admin password"
+                  aria-label="Admin password"
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   onKeyPress={(e) => e.key === "Enter" && handleLogin()}


### PR DESCRIPTION
💡 What: Added an `aria-label` to the Admin password input in the Settings view.
🎯 Why: The input field only used a `placeholder`, which is not sufficient for screen readers to properly identify the field's purpose, making it inaccessible to visually impaired users.
📸 Before/After: Visuals are unchanged as this is an invisible attribute change.
♿ Accessibility: Improved screen reader support for the authentication form.

---
*PR created automatically by Jules for task [1851605477270065009](https://jules.google.com/task/1851605477270065009) started by @scobru*