### PR TITLE
🔒 Fix path traversal vulnerability in log service endpoint

### DIFF
--- a/relay/src/routes/system.ts
+++ b/relay/src/routes/system.ts
@@ -626,6 +626,13 @@ router.get("/services/:name/logs", adminAuthMiddleware, (req, res) => {
     // Normalize service name
     const normalizedName = (serviceName as string).toLowerCase().replace(/%20/g, ' ').trim();
 
+    if (normalizedName.includes("..") || normalizedName.includes("/") || normalizedName.includes("\\")) {
+      return res.status(400).json({
+        success: false,
+        error: "Invalid service name",
+      });
+    }
+
     if (normalizedName.includes("ipfs")) {
       // Check common IPFS log locations or PM2
       logFile = "/var/log/supervisor/ipfs.log"; // Supervisor default

--- a/relay/src/tests/system-routes-traversal.test.ts
+++ b/relay/src/tests/system-routes-traversal.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import systemRouter from "../routes/system";
+import fs from "fs";
+
+// Mock dependencies
+vi.mock("../utils/logger", () => ({
+  loggers: {
+    server: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../config", () => ({
+  packageConfig: { version: "1.0.0" },
+  authConfig: { adminPassword: "test-password" },
+}));
+
+vi.mock("../config/env-config", () => ({
+  config: {
+    relay: { name: "Test Relay" },
+  },
+  driveConfig: {
+      dataDir: "/tmp/test-data",
+  }
+}));
+
+vi.mock("../utils/gun-paths", () => ({
+  GUN_PATHS: {
+    SHOGUN: "shogun",
+    LOGS: "logs",
+  },
+  getGunNode: vi.fn(() => ({
+    once: vi.fn(),
+    put: vi.fn(),
+    get: vi.fn(() => ({ put: vi.fn() })),
+  })),
+}));
+
+// Mock admin-auth middleware to allow all requests
+vi.mock("../middleware/admin-auth", () => ({
+  adminAuthMiddleware: (req: any, res: any, next: any) => {
+    next();
+  },
+}));
+
+describe("System Routes Path Traversal", () => {
+  let app: express.Application;
+  let server: any;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    app = express();
+    app.use(express.json());
+
+    // Mock app.get for gunInstance
+    app.use((req, res, next) => {
+      req.app.set("gunInstance", {});
+      req.app.set("relayUserPub", "test-pub-key");
+      next();
+    });
+
+    app.use("/system", systemRouter);
+
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        const addr = server.address() as any;
+        baseUrl = `http://localhost:${addr.port}`;
+        resolve(null);
+      });
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it("should block path traversal via /services/:name/logs", async () => {
+    // We are trying to reach something like /etc/passwd or a different log
+    // `normalizedName` will be something like "../../etc/passwd"
+    const maliciousServiceName = encodeURIComponent("../../etc/passwd");
+
+    // We mock fs.existsSync and fs.readFileSync to check if we attempt to read the malicious path
+    const existsSyncSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync").mockReturnValue("test log content");
+
+    try {
+        const res = await fetch(`${baseUrl}/system/services/${maliciousServiceName}/logs`);
+        expect(res.status).toBe(400); // the route should reject the input
+
+        const body = await res.json() as any;
+        console.log(body);
+
+        // Check if the read path contains the traversal characters
+        const readCalls = readFileSyncSpy.mock.calls;
+        if (readCalls.length > 0) {
+            const attemptedPath = readCalls[0][0] as string;
+            console.log("Attempted to read file:", attemptedPath);
+            // We want to ensure it DOES NOT resolve to outside the log directory,
+            // or we should reject it completely (e.g. 400 Bad Request)
+            expect(attemptedPath).not.toContain("../");
+            expect(attemptedPath).not.toBe("/etc/passwd");
+        }
+    } finally {
+        existsSyncSpy.mockRestore();
+        readFileSyncSpy.mockRestore();
+    }
+  });
+
+  it("should allow safe service names via /services/:name/logs", async () => {
+    const safeServiceName = "ipfs";
+
+    const existsSyncSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync").mockReturnValue("test log content ipfs");
+
+    const res = await fetch(`${baseUrl}/system/services/${safeServiceName}/logs`);
+    expect(res.status).toBe(200);
+
+    existsSyncSpy.mockRestore();
+    readFileSyncSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Path Traversal (CWE-22) issue in the `/services/:name/logs` endpoint, which is used to read service log files.
⚠️ **Risk:** The potential impact if left unfixed is that an attacker with admin credentials (since the endpoint requires admin token authentication) could supply directory traversal sequences (`..`, `/`, `\`) in the `:name` parameter to construct file paths outside of the intended `/var/log/supervisor/` directory. Depending on the operating system and the presence of accessible `.log` files or null-byte injection vulnerabilities, this could allow an attacker to read arbitrary log files (or potentially other files) from the file system.
🛡️ **Solution:** The fix addresses the vulnerability by explicitly checking the user-provided `serviceName` for directory traversal characters (`..`, `/`, `\`) *after* normalization. If any of these characters are found, the endpoint immediately returns a `400 Bad Request` status code, preventing the construction of malicious file paths. This ensures that the path stays within the intended log directories.

Additionally, a test case has been created in `relay/src/tests/system-routes-traversal.test.ts` to verify the fix works correctly by simulating traversal attempts and confirming the 400 response. Tests pass, and no regression is introduced.

---
*PR created automatically by Jules for task [9263783848093913437](https://jules.google.com/task/9263783848093913437) started by @scobru*