### PR TITLE
🧹 Remove redundant imports of fs and path

### DIFF
--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -707,8 +707,8 @@ async function initializeServer() {
     }
   } else if (relayKeysConfig.seaKeypairPath) {
     try {
-      const fs = await import("fs");
-      const path = await import("path");
+
+
 
       // Determine the actual keypair file path
       let keypairFilePath = relayKeysConfig.seaKeypairPath;
@@ -773,8 +773,8 @@ async function initializeServer() {
     loggers.server.warn(`⚠️ No keypair configured. Attempting to auto-generate...`);
 
     try {
-      const fs = await import("fs");
-      const path = await import("path");
+
+
 
       // Try default locations
       const defaultPaths = [


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a "Redundant Import of fs". Specifically, `fs` (and `path`) were statically imported at the top of `relay/src/index.ts` but were unnecessarily dynamically imported using `await import()` later in the file inside a `try/catch` block.

💡 **Why:** Replacing dynamic imports with the existing top-level static imports improves codebase maintainability, reduces complexity, fixes the linting/code health warning, and slightly boosts performance by removing unnecessary asynchronous calls for standard Node.js modules.

✅ **Verification:**
1. Ran `pnpm run build:ts` to verify the codebase compiles.
2. Ran `pnpm lint` to ensure code health is good.
3. Ran `pnpm test` (Vitest) to verify that all current tests continue to pass and no regressions were introduced.

✨ **Result:** A cleaner `relay/src/index.ts` file without unnecessary and redundant dynamic module imports for built-in packages.

---
*PR created automatically by Jules for task [11227721649319276737](https://jules.google.com/task/11227721649319276737) started by @scobru*