### PR TITLE
🧹 Fix S3 directory move and rename logic in MinioStorageAdapter

### DIFF
--- a/relay/src/utils/storage-adapter.test.ts
+++ b/relay/src/utils/storage-adapter.test.ts
@@ -1,16 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import path from "path";
-import { FsStorageAdapter } from "./storage-adapter";
+import { FsStorageAdapter, MinioStorageAdapter } from "./storage-adapter";
 import fs from "fs";
 import { promises as fsPromises } from "fs";
+import { S3Client, ListObjectsV2Command, CopyObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 
 // Mock env-config
 vi.mock("../config/env-config", () => ({
   driveConfig: {
     dataDir: "/tmp/test-drive",
-    storageType: "fs",
+    storageType: "minio",
+    minio: {
+      endpoint: "http://localhost:9000",
+      accessKey: "minioadmin",
+      secretKey: "minioadmin",
+      bucket: "test-bucket",
+      region: "us-east-1"
+    }
   },
 }));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  return {
+    S3Client: vi.fn(() => ({
+      send: vi.fn()
+    })),
+    ListObjectsV2Command: vi.fn((input) => ({ type: 'ListObjectsV2', input })),
+    CopyObjectCommand: vi.fn((input) => ({ type: 'CopyObject', input })),
+    DeleteObjectCommand: vi.fn((input) => ({ type: 'DeleteObject', input })),
+    HeadBucketCommand: vi.fn((input) => ({ type: 'HeadBucket', input })),
+    CreateBucketCommand: vi.fn((input) => ({ type: 'CreateBucket', input }))
+  };
+});
 
 // Mock logger
 vi.mock("./logger", () => ({
@@ -127,6 +148,157 @@ describe("FsStorageAdapter", () => {
       expect(stats.totalBytes).toBe(0);
       expect(stats.fileCount).toBe(0);
       expect(stats.dirCount).toBe(0);
+    });
+  });
+});
+
+describe("MinioStorageAdapter", () => {
+  let adapter: MinioStorageAdapter;
+  let mockSend: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new MinioStorageAdapter();
+    // Bypass background bucket creation in tests for simpler mocking
+    (adapter as any).initialized = true;
+    mockSend = (adapter as any).client.send;
+  });
+
+  describe("renameItem", () => {
+    it("should rename a file (single object copy and delete)", async () => {
+      // Mock list objects to return empty (indicating it's a file, not a prefix/directory)
+      mockSend.mockResolvedValueOnce({ Contents: [] }); // First send is ListObjectsV2Command
+
+      await adapter.renameItem("old-file.txt", "new-file.txt");
+
+      // Verify copy was called for file
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          Bucket: "test-bucket",
+          CopySource: "test-bucket/old-file.txt",
+          Key: "new-file.txt"
+        })
+      }));
+
+      // Verify delete was called for old file
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Bucket: "test-bucket",
+          Key: "old-file.txt"
+        })
+      }));
+    });
+
+    it("should recursively rename a directory", async () => {
+      // Mock list objects to return items (indicating it's a directory)
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: "old-dir/file1.txt" }]
+      }); // For the check
+
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: "old-dir/file1.txt" }, { Key: "old-dir/file2.txt" }]
+      }); // For getting all objects
+
+      await adapter.renameItem("old-dir", "new-dir");
+
+      // Verify copies
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          CopySource: "test-bucket/old-dir/file1.txt",
+          Key: "new-dir/file1.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          CopySource: "test-bucket/old-dir/file2.txt",
+          Key: "new-dir/file2.txt"
+        })
+      }));
+
+      // Verify deletes
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Key: "old-dir/file1.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Key: "old-dir/file2.txt"
+        })
+      }));
+    });
+  });
+
+  describe("moveItem", () => {
+    it("should move a file", async () => {
+      mockSend.mockResolvedValueOnce({ Contents: [] }); // File check
+
+      await adapter.moveItem("source.txt", "dest/source.txt");
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          CopySource: "test-bucket/source.txt",
+          Key: "dest/source.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Key: "source.txt"
+        })
+      }));
+    });
+
+    it("should recursively move a directory", async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: "src-dir/file.txt" }]
+      });
+
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: "src-dir/file.txt" }, { Key: "src-dir/sub/file2.txt" }]
+      });
+
+      await adapter.moveItem("src-dir", "dest-dir");
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          CopySource: "test-bucket/src-dir/file.txt",
+          Key: "dest-dir/file.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'CopyObject',
+        input: expect.objectContaining({
+          CopySource: "test-bucket/src-dir/sub/file2.txt",
+          Key: "dest-dir/sub/file2.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Key: "src-dir/file.txt"
+        })
+      }));
+
+      expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'DeleteObject',
+        input: expect.objectContaining({
+          Key: "src-dir/sub/file2.txt"
+        })
+      }));
     });
   });
 });

--- a/relay/src/utils/storage-adapter.ts
+++ b/relay/src/utils/storage-adapter.ts
@@ -679,23 +679,77 @@ export class MinioStorageAdapter implements IStorageAdapter {
     const parentPath = oldKey.includes("/") ? oldKey.substring(0, oldKey.lastIndexOf("/")) : "";
     const newKey = parentPath ? `${parentPath}/${newName}` : newName;
 
-    // Copy and delete (S3 doesn't have rename)
-    await this.client.send(
-      new CopyObjectCommand({
+    // Check if it's a directory by listing objects with this prefix
+    const listResponse = await this.client.send(
+      new ListObjectsV2Command({
         Bucket: this.bucket,
-        CopySource: `${this.bucket}/${oldKey}`,
-        Key: newKey,
+        Prefix: `${oldKey}/`,
+        MaxKeys: 1,
       })
     );
 
-    await this.client.send(
-      new DeleteObjectCommand({
-        Bucket: this.bucket,
-        Key: oldKey,
-      })
-    );
+    if (listResponse.Contents && listResponse.Contents.length > 0) {
+      // It's a directory - rename all objects with this prefix
+      let continuationToken: string | undefined;
 
-    loggers.server.info({ oldPath, newName }, "🪣 Item renamed (minio)");
+      do {
+        const allObjects = await this.client.send(
+          new ListObjectsV2Command({
+            Bucket: this.bucket,
+            Prefix: `${oldKey}/`,
+            ContinuationToken: continuationToken,
+          })
+        );
+
+        if (allObjects.Contents && allObjects.Contents.length > 0) {
+          const chunkSize = 10;
+          for (let i = 0; i < allObjects.Contents.length; i += chunkSize) {
+            const chunk = allObjects.Contents.slice(i, i + chunkSize);
+            await Promise.all(
+              chunk.map(async (obj) => {
+                if (obj.Key) {
+                  const destKey = obj.Key.replace(oldKey, newKey);
+                  await this.client.send(
+                    new CopyObjectCommand({
+                      Bucket: this.bucket,
+                      CopySource: `${this.bucket}/${obj.Key}`,
+                      Key: destKey,
+                    })
+                  );
+                  await this.client.send(
+                    new DeleteObjectCommand({
+                      Bucket: this.bucket,
+                      Key: obj.Key,
+                    })
+                  );
+                }
+              })
+            );
+          }
+        }
+
+        continuationToken = allObjects.NextContinuationToken;
+      } while (continuationToken);
+
+      loggers.server.info({ oldPath, newName }, "🪣 Directory renamed (minio)");
+    } else {
+      // It's a file
+      await this.client.send(
+        new CopyObjectCommand({
+          Bucket: this.bucket,
+          CopySource: `${this.bucket}/${oldKey}`,
+          Key: newKey,
+        })
+      );
+
+      await this.client.send(
+        new DeleteObjectCommand({
+          Bucket: this.bucket,
+          Key: oldKey,
+        })
+      );
+      loggers.server.info({ oldPath, newName }, "🪣 Item renamed (minio)");
+    }
   }
 
   async moveItem(sourcePath: string, destPath: string): Promise<void> {
@@ -704,23 +758,77 @@ export class MinioStorageAdapter implements IStorageAdapter {
     const sourceKey = this.validatePath(sourcePath);
     const destKey = this.validatePath(destPath);
 
-    // Copy and delete
-    await this.client.send(
-      new CopyObjectCommand({
+    // Check if it's a directory by listing objects with this prefix
+    const listResponse = await this.client.send(
+      new ListObjectsV2Command({
         Bucket: this.bucket,
-        CopySource: `${this.bucket}/${sourceKey}`,
-        Key: destKey,
+        Prefix: `${sourceKey}/`,
+        MaxKeys: 1,
       })
     );
 
-    await this.client.send(
-      new DeleteObjectCommand({
-        Bucket: this.bucket,
-        Key: sourceKey,
-      })
-    );
+    if (listResponse.Contents && listResponse.Contents.length > 0) {
+      // It's a directory - move all objects with this prefix
+      let continuationToken: string | undefined;
 
-    loggers.server.info({ sourcePath, destPath }, "🪣 Item moved (minio)");
+      do {
+        const allObjects = await this.client.send(
+          new ListObjectsV2Command({
+            Bucket: this.bucket,
+            Prefix: `${sourceKey}/`,
+            ContinuationToken: continuationToken,
+          })
+        );
+
+        if (allObjects.Contents && allObjects.Contents.length > 0) {
+          const chunkSize = 10;
+          for (let i = 0; i < allObjects.Contents.length; i += chunkSize) {
+            const chunk = allObjects.Contents.slice(i, i + chunkSize);
+            await Promise.all(
+              chunk.map(async (obj) => {
+                if (obj.Key) {
+                  const objDestKey = obj.Key.replace(sourceKey, destKey);
+                  await this.client.send(
+                    new CopyObjectCommand({
+                      Bucket: this.bucket,
+                      CopySource: `${this.bucket}/${obj.Key}`,
+                      Key: objDestKey,
+                    })
+                  );
+                  await this.client.send(
+                    new DeleteObjectCommand({
+                      Bucket: this.bucket,
+                      Key: obj.Key,
+                    })
+                  );
+                }
+              })
+            );
+          }
+        }
+
+        continuationToken = allObjects.NextContinuationToken;
+      } while (continuationToken);
+
+      loggers.server.info({ sourcePath, destPath }, "🪣 Directory moved (minio)");
+    } else {
+      // It's a file
+      await this.client.send(
+        new CopyObjectCommand({
+          Bucket: this.bucket,
+          CopySource: `${this.bucket}/${sourceKey}`,
+          Key: destKey,
+        })
+      );
+
+      await this.client.send(
+        new DeleteObjectCommand({
+          Bucket: this.bucket,
+          Key: sourceKey,
+        })
+      );
+      loggers.server.info({ sourcePath, destPath }, "🪣 Item moved (minio)");
+    }
   }
 
   async getStorageStats(): Promise<StorageStats> {


### PR DESCRIPTION
🎯 **What:** 
Fixed a code health and functional bug in `MinioStorageAdapter.renameItem` and `MinioStorageAdapter.moveItem`. The previous implementation incorrectly assumed S3 had a standard "rename" functionality or that moving a single prefix key would move a directory. Since S3 directories are virtual, this resulted in only the placeholder key (if present) being moved, leaving all nested objects behind. 

The new implementation:
- Uses `ListObjectsV2Command` to detect if the item is a directory (has nested objects under that prefix).
- Paginates via `NextContinuationToken` to fetch all files if the list exceeds 1,000 files.
- Processes objects in chunks of 10 (`Promise.all()`) by sequentially replacing the prefix in their keys and invoking `CopyObjectCommand` and `DeleteObjectCommand`.
- Retains the fast path fallback for single files.

💡 **Why:** 
This prevents silent data loss or stale data accumulation when users manipulate "folders" via the dashboard, ensuring S3 operations mirror `fs` operations reliably. The batched concurrency avoids network waterfall blocking on large directories.

✅ **Verification:** 
- Updated `storage-adapter.test.ts` to fully mock `S3Client`.
- Tests verify both the single file paths and the recursive directory paths for both operations.
- `vitest` suite passes flawlessly without hanging.
- Pre-commit lint passes successfully.

✨ **Result:** 
Moving or renaming directories inside MinIO/S3 now functions intuitively and performantly without breaking edge cases with thousands of files.

---
*PR created automatically by Jules for task [13285551955120509261](https://jules.google.com/task/13285551955120509261) started by @scobru*