### PR TITLE
fix: resolve uuid error in visual graph by replacing react-vis-network-graph

### DIFF
--- a/relay/package.json
+++ b/relay/package.json
@@ -56,15 +56,17 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
-    "react-vis-network-graph": "^3.0.1",
     "recharts": "^3.6.0",
     "self-adjusting-interval": "^1.0.0",
     "short-uuid": "^6.0.3",
     "tsx": "^4.19.2",
-    "vis-network": "^10.0.2"
+    "uuid": "9.0.1",
+    "vis-data": "7.1.9",
+    "vis-network": "9.1.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "latest",
     "@types/better-sqlite3": "^7.6.13",
     "@types/cors": "^2.8.19",
@@ -73,6 +75,7 @@
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
+    "@types/uuid": "^11.0.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^2.1.0",
     "@vitest/ui": "^2.1.9",

--- a/relay/pnpm-lock.yaml
+++ b/relay/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       react-router-dom:
         specifier: ^6.20.0
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-vis-network-graph:
-        specifier: ^3.0.1
-        version: 3.0.1(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(moment@2.30.1)(timsort@0.3.0)(vis-util@4.3.4)
       recharts:
         specifier: ^3.6.0
         version: 3.8.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1)
@@ -92,13 +89,22 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      uuid:
+        specifier: 9.0.1
+        version: 9.0.1
+      vis-data:
+        specifier: 7.1.9
+        version: 7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
       vis-network:
-        specifier: ^10.0.2
-        version: 10.0.2(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(uuid@10.0.0)(vis-data@6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4))(vis-util@4.3.4)
+        specifier: 9.1.9
+        version: 9.1.9(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/vite':
         specifier: latest
         version: 4.2.2(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0))
@@ -123,6 +129,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.17
         version: 18.3.7(@types/react@18.3.28)
+      '@types/uuid':
+        specifier: ^11.0.0
+        version: 11.0.0
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.7.0(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0))
@@ -831,6 +840,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -1444,6 +1458,10 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/uuid@11.0.0':
+    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
+    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/vis@4.21.27':
     resolution: {integrity: sha512-Ma/W/XgSXu9ltuJfKRqS27CVcYNxf+sM8M76F82zWSyB/s/gT+Vw2f8LZhWN+GSnDQ1XahdBKhTtGZi4IK3pzA==}
@@ -2188,6 +2206,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2515,9 +2538,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2754,6 +2774,16 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -2778,9 +2808,6 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -2862,13 +2889,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
-
-  react-vis-network-graph@3.0.1:
-    resolution: {integrity: sha512-gxUOJDPb+w7sZxvSzIrV7YpOqoJiTF6YrPsXS3RGnrmZnWyGhpCpUcaPli4PDsqpI74Q4f5AICg0cdzAEVbmIQ==}
-
-  react@16.14.0:
-    resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==}
-    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -3114,9 +3134,6 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
-  timsort@0.3.0:
-    resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -3236,9 +3253,9 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  uuid@2.0.3:
-    resolution: {integrity: sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3247,38 +3264,28 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vis-data@6.6.1:
-    resolution: {integrity: sha512-xmujDB2Dzf8T04rGFJ9OP4OA6zRVrz8R9hb0CVKryBrZRCljCga9JjSfgctA8S7wdZu7otDtUIwX4ZOgfV/57w==}
+  vis-data@7.1.9:
+    resolution: {integrity: sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==}
     peerDependencies:
-      moment: ^2.24.0
-      uuid: ^7.0.0 || ^8.0.0
-      vis-util: ^4.0.0
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      vis-util: ^5.0.1
 
-  vis-network@10.0.2:
-    resolution: {integrity: sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==}
-    peerDependencies:
-      '@egjs/hammerjs': ^2.0.0
-      component-emitter: ^1.3.0 || ^2.0.0
-      keycharm: ^0.2.0 || ^0.3.0 || ^0.4.0
-      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0
-      vis-data: '>=8.0.0'
-      vis-util: '>=6.0.0'
-
-  vis-network@7.10.2:
-    resolution: {integrity: sha512-KDx2agbDnaiE0Bye4AcCRqTn5mxzDKhdUNpKkzSn0AOLBmdhNtPGjxAFluAmvFVyiSK5R6Q5KIWdLjeIMu/PAQ==}
+  vis-network@9.1.9:
+    resolution: {integrity: sha512-Ft+hLBVyiLstVYSb69Q1OIQeh3FeUxHJn0WdFcq+BFPqs+Vq1ibMi2sb//cxgq1CP7PH4yOXnHxEH/B2VzpZYA==}
     peerDependencies:
       '@egjs/hammerjs': ^2.0.0
       component-emitter: ^1.3.0
-      keycharm: ^0.2.0 || ^0.3.0
-      moment: ^2.24.0
-      timsort: ^0.3.0
-      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0
-      vis-data: ^6.2.1
-      vis-util: ^3.0.0 || ^4.0.0
+      keycharm: ^0.2.0 || ^0.3.0 || ^0.4.0
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      vis-data: ^6.3.0 || ^7.0.0
+      vis-util: ^5.0.1
 
-  vis-util@4.3.4:
-    resolution: {integrity: sha512-hJIZNrwf4ML7FYjs+m+zjJfaNvhjk3/1hbMdQZVnwwpOFJS/8dMG8rdbOHXcKoIEM6U5VOh3HNpaDXxGkOZGpw==}
+  vis-util@5.0.7:
+    resolution: {integrity: sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==}
     engines: {node: '>=8'}
+    peerDependencies:
+      '@egjs/hammerjs': ^2.0.0
+      component-emitter: ^1.3.0 || ^2.0.0
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -4256,6 +4263,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@polka/url@1.0.0-next.29': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -4912,6 +4923,10 @@ snapshots:
       '@types/node': 20.19.37
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/uuid@11.0.0':
+    dependencies:
+      uuid: 9.0.1
 
   '@types/vis@4.21.27':
     dependencies:
@@ -5790,6 +5805,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6063,8 +6081,6 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
-
   long@5.3.2: {}
 
   loose-envify@1.4.0:
@@ -6287,6 +6303,14 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
 
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.8:
@@ -6315,12 +6339,6 @@ snapshots:
   prettier@3.8.1: {}
 
   process-warning@5.0.0: {}
-
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
 
   protobufjs@7.5.4:
     dependencies:
@@ -6411,28 +6429,6 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.2
       react: 18.3.1
-
-  react-vis-network-graph@3.0.1(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(moment@2.30.1)(timsort@0.3.0)(vis-util@4.3.4):
-    dependencies:
-      lodash: 4.17.23
-      prop-types: 15.8.1
-      react: 16.14.0
-      uuid: 2.0.3
-      vis-data: 6.6.1(moment@2.30.1)(uuid@2.0.3)(vis-util@4.3.4)
-      vis-network: 7.10.2(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(moment@2.30.1)(timsort@0.3.0)(uuid@2.0.3)(vis-data@6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4))(vis-util@4.3.4)
-    transitivePeerDependencies:
-      - '@egjs/hammerjs'
-      - component-emitter
-      - keycharm
-      - moment
-      - timsort
-      - vis-util
-
-  react@16.14.0:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.8.1
 
   react@18.3.1:
     dependencies:
@@ -6725,8 +6721,6 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
-  timsort@0.3.0: {}
-
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -6823,7 +6817,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  uuid@2.0.3: {}
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -6844,39 +6838,24 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vis-data@6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4):
+  vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
-      moment: 2.30.1
-      uuid: 10.0.0
-      vis-util: 4.3.4
+      uuid: 9.0.1
+      vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
-  vis-data@6.6.1(moment@2.30.1)(uuid@2.0.3)(vis-util@4.3.4):
-    dependencies:
-      moment: 2.30.1
-      uuid: 2.0.3
-      vis-util: 4.3.4
-
-  vis-network@10.0.2(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(uuid@10.0.0)(vis-data@6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4))(vis-util@4.3.4):
+  vis-network@9.1.9(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       component-emitter: 1.3.1
       keycharm: 0.3.1
-      uuid: 10.0.0
-      vis-data: 6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4)
-      vis-util: 4.3.4
+      uuid: 9.0.1
+      vis-data: 7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
-  vis-network@7.10.2(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.3.1)(moment@2.30.1)(timsort@0.3.0)(uuid@2.0.3)(vis-data@6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4))(vis-util@4.3.4):
+  vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       component-emitter: 1.3.1
-      keycharm: 0.3.1
-      moment: 2.30.1
-      timsort: 0.3.0
-      uuid: 2.0.3
-      vis-data: 6.6.1(moment@2.30.1)(uuid@10.0.0)(vis-util@4.3.4)
-      vis-util: 4.3.4
-
-  vis-util@4.3.4: {}
 
   vite-node@2.1.9(@types/node@20.19.37)(lightningcss@1.32.0):
     dependencies:

--- a/relay/src/public/dashboard/src/components/Graph.tsx
+++ b/relay/src/public/dashboard/src/components/Graph.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from "react";
+import { Network, Options } from "vis-network";
+import { DataSet } from "vis-data";
+
+interface GraphProps {
+  graph: {
+    nodes: any[];
+    edges: any[];
+  };
+  options?: Options;
+  events?: {
+    [event: string]: (params?: any) => void;
+  };
+}
+
+const Graph: React.FC<GraphProps> = ({ graph, options, events }) => {
+  const container = useRef<HTMLDivElement>(null);
+  const networkRef = useRef<Network | null>(null);
+
+  useEffect(() => {
+    if (container.current) {
+      const data = {
+        nodes: new DataSet(graph.nodes),
+        edges: new DataSet(graph.edges)
+      };
+
+      networkRef.current = new Network(container.current, data, options || {});
+
+      if (events && networkRef.current) {
+        Object.keys(events).forEach(eventName => {
+          networkRef.current!.on(eventName as any, events[eventName]);
+        });
+      }
+    }
+
+    return () => {
+      if (networkRef.current) {
+        networkRef.current.destroy();
+        networkRef.current = null;
+      }
+    };
+  }, [graph, options, events]);
+
+  return <div ref={container} style={{ height: "100%", width: "100%" }} />;
+};
+
+export default Graph;

--- a/relay/src/public/dashboard/src/views/VisualGraph.tsx
+++ b/relay/src/public/dashboard/src/views/VisualGraph.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import Graph from "react-vis-network-graph";
+import Graph from "../components/Graph";
 import { useAuth } from "../context/AuthContext";
 import { GUN_PATHS } from "../utils/gun-paths";
 

--- a/relay/src/public/dashboard/vite.config.ts
+++ b/relay/src/public/dashboard/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import path from "path";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -19,5 +20,5 @@ export default defineConfig({
   build: {
     outDir: "dist",
     assetsDir: "assets",
-  },
+  }
 });

--- a/relay/test-results/.last-run.json
+++ b/relay/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/relay/test.spec.js
+++ b/relay/test.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('graph', async ({ page }) => {
+  page.on('console', msg => console.log('LOG:', msg.text()));
+  page.on('pageerror', err => console.log('ERROR:', err.message));
+  await page.goto('http://localhost:3000/dashboard/visual-graph');
+  await page.waitForTimeout(1000);
+});

--- a/test.spec.js
+++ b/test.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('graph', async ({ page }) => {
+  page.on('console', msg => console.log('LOG:', msg.text()));
+  page.on('pageerror', err => console.log('ERROR:', err.message));
+  await page.goto('http://localhost:3000/dashboard/visual-graph');
+  await page.waitForTimeout(1000);
+});


### PR DESCRIPTION
Replaced `react-vis-network-graph` with a direct wrapper utilizing `vis-network` and `vis-data` natively to resolve runtime `Cannot read properties of undefined (reading 'v4')` errors caused by outdated embedded dependencies in Vite frontend builds.

---
*PR created automatically by Jules for task [15473941689602779372](https://jules.google.com/task/15473941689602779372) started by @scobru*