### PR TITLE
🧹 Add logging to empty catch block for URL parsing in network.ts

### DIFF
--- a/relay/src/routes/network.ts
+++ b/relay/src/routes/network.ts
@@ -1103,6 +1103,7 @@ router.get("/reputation/:host", async (req, res) => {
               }
             }
           } catch (e) {
+            loggers.server.warn({ err: e, relayHost }, 'Failed to parse relay endpoint URL');
             // Ignore URL parsing errors
           }
         }


### PR DESCRIPTION
🎯 **What:** Added a `loggers.server.warn` statement to an empty catch block in `relay/src/routes/network.ts` that handles URL parsing errors for relay endpoints.
💡 **Why:** Silently ignoring URL parsing errors can hide configuration issues or malformed data, making the system difficult to troubleshoot. Logging the error along with context (the problematic `relayHost`) improves observability and maintainability.
✅ **Verification:** Ran the full backend test suite via `pnpm test` to ensure no functionality is broken. Manually verified that the change does not introduce side effects and is limited solely to the logging statement.
✨ **Result:** Malformed relay endpoint URLs will now be properly logged as warnings instead of failing silently, facilitating easier debugging and robust operation.

---
*PR created automatically by Jules for task [4327504124584242636](https://jules.google.com/task/4327504124584242636) started by @scobru*