### PR TITLE
🧹 Handle empty catch block with a debug log in system.ts

### DIFF
--- a/relay/src/routes/system.ts
+++ b/relay/src/routes/system.ts
@@ -494,7 +494,8 @@ router.get("/logs", adminAuthMiddleware, async (req, res) => {
         await fs.promises.access(loc, fs.constants.R_OK);
         logFilePath = loc;
         break;
-      } catch (err) {
+      } catch (err: any) {
+        loggers.server.debug({ loc, err: err.message }, "Log file not found at location, trying next");
         // Skip and try next location
       }
     }


### PR DESCRIPTION
🎯 **What:** Handled an empty catch block in `relay/src/routes/system.ts` by adding a debug level log using `loggers.server.debug`.
💡 **Why:** It improves the observability of the codebase. Instead of silently swallowing the error when a log file is not found at the expected location, it now logs a debug message that can be helpful for troubleshooting without affecting the program's normal flow.
✅ **Verification:** Ran `pnpm lint` and `pnpm test` successfully. Verified the changes locally to make sure it functions as intended.
✨ **Result:** Better visibility when `relay/src/routes/system.ts` tries to search for log files.

---
*PR created automatically by Jules for task [13953958229334077877](https://jules.google.com/task/13953958229334077877) started by @scobru*