### PR TITLE
🔒 Security: Prevent exposure of user private keys on login

### DIFF
--- a/relay/src/routes/auth.ts
+++ b/relay/src/routes/auth.ts
@@ -70,6 +70,7 @@ router.post("/register", async (req: Request, res: Response) => {
             success: true,
             username: username,
             pub: ack.pub,
+            epub: ack.epub,
             alias: ack.sea.alias, // Typically same as username
             message: "User registered successfully",
           });
@@ -122,7 +123,6 @@ router.post("/login", async (req: Request, res: Response) => {
             pub: ack.pub,
             epub: ack.epub,
             alias: ack.sea.alias,
-            sea: ack.sea, // Return the SEA pair so client can use it if needed (be careful!)
           });
           user.leave(); // Don't leave session open on server
           resolve(ack);

--- a/relay/src/tests/auth-security.test.ts
+++ b/relay/src/tests/auth-security.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import authRouter from "../routes/auth";
+
+// Mock logger to avoid spam
+vi.mock("../utils/logger", () => ({
+  loggers: {
+    server: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+describe("Auth Security", () => {
+  let app: express.Application;
+  let mockGun: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+
+    mockGun = {
+      user: vi.fn().mockReturnValue({
+        auth: vi.fn((username, password, cb) => {
+          cb({
+            err: null,
+            pub: "test-pub",
+            epub: "test-epub",
+            sea: {
+              pub: "test-pub",
+              priv: "test-priv-sensitive",
+              epub: "test-epub",
+              epriv: "test-epriv-sensitive",
+              alias: "test-user"
+            }
+          });
+        }),
+        leave: vi.fn(),
+        create: vi.fn((username, password, cb) => {
+            cb({ ok: 0 });
+        })
+      }),
+      get: vi.fn().mockReturnValue({
+        once: vi.fn((cb) => cb(null))
+      })
+    };
+
+    app.set("gunInstance", mockGun);
+    app.use("/api/v1/auth", authRouter);
+  });
+
+  it("should NOT return private keys on login", async () => {
+    const response = await request(app)
+      .post("/api/v1/auth/login")
+      .send({ username: "test-user", password: "test-password" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.pub).toBe("test-pub");
+    expect(response.body.epub).toBe("test-epub");
+
+    // The vulnerability: sea contains priv and epriv
+    // In the failing state, response.body.sea will be defined
+    expect(response.body.sea).toBeUndefined();
+  });
+
+  it("should NOT return private keys on register", async () => {
+    const response = await request(app)
+      .post("/api/v1/auth/register")
+      .send({ username: "test-user", password: "test-password" });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+
+    expect(response.body.sea).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The relay server's authentication routes were exposing sensitive user data. Specifically, the `login` endpoint was returning the full `sea` object from GunDB, which contains the user's private signing key (`priv`) and private encryption key (`epriv`). This allowed anyone with access to the login response to completely impersonate the user and decrypt their private data.

This PR fixes the vulnerability by:
1.  **Removing private key exposure**: The `sea` property has been removed from the response payload in `relay/src/routes/auth.ts`.
2.  **Maintaining public metadata**: The `pub` (signing), `epub` (encryption), and `alias` fields continue to be returned as they are public information.
3.  **Improving consistency**: The `epub` field was added to the registration response so that clients have all necessary public keys immediately upon account creation.
4.  **Regression testing**: A new Vitest suite was added to ensure that future changes do not accidentally re-expose the `sea` object.

Impact: All users logging in via the Relay API are now protected from private key leakage via the server response. Existing clients that correctly manage keys locally will not be affected. Any (insecure) clients that relied on the server to provide their own private keys will need to be updated to manage keys using the user's password.

---
*PR created automatically by Jules for task [4124655866199429383](https://jules.google.com/task/4124655866199429383) started by @scobru*