### PR TITLE
⚡ Parallelize Alias Existence Checks in Alias Maintenance

### DIFF
--- a/relay/src/utils/alias-maintenance.ts
+++ b/relay/src/utils/alias-maintenance.ts
@@ -64,22 +64,24 @@ export async function performAliasMaintenance(gun: any): Promise<MaintenanceStat
                 // b. The one that was most recently 'put' (if we had timestamps, but Gun nodes are graphs)
                 // For now, we'll check existence in USERS or just take the first one.
                 
-                let bestPub: string | null = null;
-                
-                for (const pub of pubKeys) {
-                  const existsInUsers = await new Promise((res) => {
+                // Check all public keys in parallel for existence in USERS
+                const existenceResults = await Promise.all(pubKeys.map(async (pub) => {
+                  const exists = await new Promise<boolean>((res) => {
                     const timeout = setTimeout(() => res(false), 1000);
                     getGunNode(gun, GUN_PATHS.USERS).get(pub).once((userData: any) => {
                       clearTimeout(timeout);
                       res(!!userData && userData !== null);
                     });
                   });
-                  
-                  if (existsInUsers) {
-                    bestPub = pub;
-                    log.info({ alias: aliasName, bestPub }, "Found valid identity for alias in users index");
-                    break;
-                  }
+                  return { pub, exists };
+                }));
+
+                // Keep the first one that exists in USERS
+                const validIdentity = existenceResults.find(r => r.exists);
+                let bestPub: string | null = validIdentity ? validIdentity.pub : null;
+
+                if (bestPub) {
+                  log.info({ alias: aliasName, bestPub }, "Found valid identity for alias in users index");
                 }
                 
                 if (!bestPub) {


### PR DESCRIPTION
The `performAliasMaintenance` function previously checked for the existence of public keys in the `USERS` path sequentially within a `for...of` loop. Each check involved an asynchronous GunDB `once()` call with a 1s timeout, leading to significant delays when multiple duplicate aliases were present.

I replaced this sequential loop with a `Promise.all()` operation that parallelizes these checks. A benchmark script demonstrated that for an alias with 5 public keys and a simulated 100ms I/O delay, the execution time dropped from over 500ms to approximately 100ms.

Logic was verified to ensure that the "best" public key selection still prefers the first valid identity found in the `USERS` index, maintaining functional parity with the original implementation.

---
*PR created automatically by Jules for task [8289738249076694889](https://jules.google.com/task/8289738249076694889) started by @scobru*