### PR TITLE
🔒 [Security] Fix Path Traversal Vulnerability in file serving routes

### DIFF
--- a/relay/src/routes/index.ts
+++ b/relay/src/routes/index.ts
@@ -489,7 +489,17 @@ export default (app: express.Application) => {
   // Route per servire i file JavaScript dalla directory lib
   app.get("/lib/:filename", async (req, res) => {
     const publicPath = path.resolve(__dirname, "../public");
-    const filePath = path.resolve(publicPath, "lib", req.params.filename);
+    const targetDir = path.resolve(publicPath, "lib");
+    const filePath = path.resolve(targetDir, req.params.filename);
+
+    if (!filePath.startsWith(targetDir + path.sep)) {
+      loggers.server.warn({ filename: req.params.filename }, `⚠️ Path traversal attempt blocked`);
+      return res.status(403).json({
+        success: false,
+        error: "Access denied",
+      });
+    }
+
     const exists = await fs.promises
       .access(filePath)
       .then(() => true)
@@ -521,7 +531,17 @@ export default (app: express.Application) => {
   // Route per servire i file CSS dalla directory styles
   app.get("/styles/:filename", async (req, res) => {
     const publicPath = path.resolve(__dirname, "../public");
-    const filePath = path.resolve(publicPath, "styles", req.params.filename);
+    const targetDir = path.resolve(publicPath, "styles");
+    const filePath = path.resolve(targetDir, req.params.filename);
+
+    if (!filePath.startsWith(targetDir + path.sep)) {
+      loggers.server.warn({ filename: req.params.filename }, `⚠️ Path traversal attempt blocked`);
+      return res.status(403).json({
+        success: false,
+        error: "Access denied",
+      });
+    }
+
     const exists = await fs.promises
       .access(filePath)
       .then(() => true)


### PR DESCRIPTION
🎯 **What:** The `req.params.filename` unsanitized input was directly passed to `path.resolve` in the `/lib/:filename` and `/styles/:filename` routes, exposing a path traversal vulnerability.
⚠️ **Risk:** Attackers could have exploited this issue by using payload like `../` to break out of the intended directory and read sensitive files from the server's filesystem, leading to potential data exposure and system compromise.
🛡️ **Solution:** Implemented secure path resolution by confirming the target absolute file path strictly begins with the correct directory's base path (`targetDir + path.sep`). If the user attempts traversal, the server correctly identifies it, logs the attempt, and returns a 403 Access Denied.

---
*PR created automatically by Jules for task [756245362794531591](https://jules.google.com/task/756245362794531591) started by @scobru*