### PR TITLE
🔒 Fix Overly Permissive CORS Origin Vulnerability

### DIFF
--- a/relay/package.json
+++ b/relay/package.json
@@ -90,7 +90,7 @@
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.15.0",
     "vite": "^5.0.8",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.9"
   },
   "bugs": {
     "url": "https://github.com/your-org/shogun-2/issues"

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -37,7 +37,7 @@ import {
 
 import { startWormholeCleanup } from "./utils/wormhole-cleanup";
 import { tokenAuthMiddleware } from "./middleware/token-auth";
-import { secureCompare, hashToken, createProductionErrorHandler } from "./utils/security";
+import { secureCompare, hashToken, createProductionErrorHandler, isOriginAllowed } from "./utils/security";
 
 import { GUN_PATHS, getGunNode } from "./utils/gun-paths";
 // Chat service removed
@@ -195,17 +195,11 @@ async function initializeServer() {
 
   // ===== SECURITY: CORS Configuration =====
   const corsOptions = {
-    origin: authConfig.corsOrigins.includes("*")
-      ? true // Allow all origins if '*' is configured
-      : (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+    origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
         // Allow requests with no origin (like mobile apps or curl requests)
         if (!origin) return callback(null, true);
 
-        if (
-          authConfig.corsOrigins.some(
-            (allowed: string) => allowed === origin || origin.endsWith(allowed.replace("*.", "."))
-          )
-        ) {
+        if (isOriginAllowed(origin, authConfig.corsOrigins)) {
           callback(null, true);
         } else {
           loggers.server.warn({ origin }, "CORS blocked request from origin");

--- a/relay/src/utils/security.test.ts
+++ b/relay/src/utils/security.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  secureCompare,
+  hashToken,
+  isValidEthereumAddress,
+  isValidAmount,
+  validateString,
+  isValidSignatureFormat,
+  sanitizeForLog,
+  isValidChainId,
+  getChainName,
+  sanitizeErrorForProduction,
+  isOriginAllowed
+} from "./security";
+
+// Mock the logger
+vi.mock("./logger", () => ({
+  loggers: {
+    server: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+describe("security utilities", () => {
+  describe("isOriginAllowed", () => {
+    it("should allow when * is in allowed origins", () => {
+      expect(isOriginAllowed("https://anything.com", ["*"])).toBe(true);
+      expect(isOriginAllowed("http://localhost:3000", ["https://app.com", "*"])).toBe(true);
+    });
+
+    it("should reject when allowedOrigins is empty", () => {
+      expect(isOriginAllowed("https://app.com", [])).toBe(false);
+    });
+
+    it("should allow exact matches", () => {
+      expect(isOriginAllowed("https://app.com", ["https://app.com", "http://localhost:3000"])).toBe(true);
+      expect(isOriginAllowed("http://localhost:3000", ["https://app.com", "http://localhost:3000"])).toBe(true);
+      expect(isOriginAllowed("https://sub.test.com", ["https://sub.test.com"])).toBe(true);
+    });
+
+    it("should reject prefix/suffix spoofing on exact matches", () => {
+      expect(isOriginAllowed("https://attacker-app.com", ["https://app.com"])).toBe(false);
+      expect(isOriginAllowed("https://app.com.attacker.com", ["https://app.com"])).toBe(false);
+      expect(isOriginAllowed("https://attacker-https://app.com", ["https://app.com"])).toBe(false);
+    });
+
+    it("should handle domain-only (no protocol) allowed origins securely", () => {
+      const allowed = ["myapp.com", "localhost:3000"];
+      expect(isOriginAllowed("https://myapp.com", allowed)).toBe(true);
+      expect(isOriginAllowed("http://myapp.com", allowed)).toBe(true);
+      expect(isOriginAllowed("https://myapp.com:8080", allowed)).toBe(true);
+      expect(isOriginAllowed("http://localhost:3000", allowed)).toBe(true);
+
+      // Malicious or incorrect origins
+      expect(isOriginAllowed("https://attacker-myapp.com", allowed)).toBe(false);
+      expect(isOriginAllowed("https://myapp.com.attacker.com", allowed)).toBe(false);
+      expect(isOriginAllowed("http://localhost:3001", allowed)).toBe(false);
+    });
+
+    it("should handle wildcard domains without explicit protocol", () => {
+      const allowed = ["*.test.com"];
+      expect(isOriginAllowed("https://sub.test.com", allowed)).toBe(true);
+      expect(isOriginAllowed("https://deep.sub.test.com", allowed)).toBe(true);
+      expect(isOriginAllowed("https://test.com", allowed)).toBe(true);
+      expect(isOriginAllowed("http://sub.test.com:8080", allowed)).toBe(true);
+
+      // Malicious or incorrect origins
+      expect(isOriginAllowed("https://attackertest.com", allowed)).toBe(false);
+      expect(isOriginAllowed("https://test.com.attacker.com", allowed)).toBe(false);
+    });
+
+    it("should handle wildcard domains with explicit protocol", () => {
+      const allowed = ["https://*.secure.com"];
+      expect(isOriginAllowed("https://sub.secure.com", allowed)).toBe(true);
+      expect(isOriginAllowed("https://secure.com", allowed)).toBe(true);
+
+      // Malicious or incorrect origins
+      expect(isOriginAllowed("http://sub.secure.com", allowed)).toBe(false); // Wrong protocol
+      expect(isOriginAllowed("https://attackersecure.com", allowed)).toBe(false);
+    });
+
+    it("should safely ignore unparseable invalid origins", () => {
+      expect(isOriginAllowed("not-a-valid-url", ["https://app.com", "myapp.com"])).toBe(false);
+    });
+  });
+});

--- a/relay/src/utils/security.ts
+++ b/relay/src/utils/security.ts
@@ -371,3 +371,42 @@ export function createProductionErrorHandler(
     });
   };
 }
+
+/**
+ * Validates if an origin is allowed based on an array of allowed origins.
+ * Properly handles wildcards and exact matches to prevent sub-domain or prefix spoofing.
+ */
+export function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
+  if (!allowedOrigins || allowedOrigins.length === 0) return false;
+  if (allowedOrigins.includes("*")) return true;
+
+  return allowedOrigins.some((allowed) => {
+    if (allowed === origin) return true;
+
+    try {
+      const originUrl = new URL(origin);
+
+      // Handle wildcard with explicit protocol (e.g., https://*.example.com)
+      if (allowed.includes("://*.")) {
+        const [scheme, baseDomain] = allowed.split("://*.");
+        if (originUrl.protocol !== `${scheme}:`) return false;
+        return originUrl.hostname === baseDomain || originUrl.hostname.endsWith(`.${baseDomain}`);
+      }
+
+      // Handle wildcard without explicit protocol (e.g., *.example.com)
+      if (allowed.startsWith("*.")) {
+        const baseDomain = allowed.slice(2);
+        return originUrl.hostname === baseDomain || originUrl.hostname.endsWith(`.${baseDomain}`);
+      }
+
+      // Handle exact match without explicit protocol (e.g., example.com)
+      if (!allowed.includes("://")) {
+        return originUrl.hostname === allowed || originUrl.host === allowed;
+      }
+    } catch (e) {
+      // If URL parsing fails, ignore. Exact string match is already handled above.
+    }
+
+    return false;
+  });
+}


### PR DESCRIPTION
🎯 **What:** Replaced the vulnerable `.endsWith()` string matching method used for CORS origin validation with a secure URL parsing utility `isOriginAllowed`.

⚠️ **Risk:** The previous implementation was vulnerable to Prefix/Suffix spoofing. An attacker could register a domain ending with the same string as an allowed origin (e.g. `attacker-app.com` for an allowed `app.com`) and bypass the CORS restrictions, potentially exposing sensitive data.

🛡️ **Solution:** Implemented the `isOriginAllowed` utility in `relay/src/utils/security.ts` that securely parses the requested origin and correctly compares it against exact matches and wildcards, while preventing spoofing. Also implemented extensive unit tests for edge cases.

---
*PR created automatically by Jules for task [11043915024567898437](https://jules.google.com/task/11043915024567898437) started by @scobru*