### PR TITLE
🔒 security: fix path traversal in service log reading

### DIFF
--- a/relay/src/routes/system.ts
+++ b/relay/src/routes/system.ts
@@ -680,14 +680,12 @@ router.get("/services/:name/logs", adminAuthMiddleware, async (req, res) => {
     // This assumes standard log locations or PM2 log naming convention
     let logFile = "";
 
-    // Normalize service name
+    // Normalize and validate service name
     const normalizedName = (serviceName as string).toLowerCase().replace(/%20/g, " ").trim();
 
-    if (
-      normalizedName.includes("..") ||
-      normalizedName.includes("/") ||
-      normalizedName.includes("\\")
-    ) {
+    // Strict validation to prevent path traversal and other injection attacks
+    const nameRegex = /^[a-zA-Z0-9\s\-_]+$/;
+    if (!nameRegex.test(normalizedName)) {
       return res.status(400).json({
         success: false,
         error: "Invalid service name",

--- a/relay/src/tests/service-logs-security.test.ts
+++ b/relay/src/tests/service-logs-security.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import systemRouter from "../routes/system";
+import fs from "fs";
+
+// Mock dependencies
+vi.mock("../utils/logger", () => ({
+  loggers: {
+    server: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../config", () => ({
+  packageConfig: { version: "1.0.0" },
+  authConfig: { adminPassword: "test-password" },
+}));
+
+vi.mock("../config/env-config", () => ({
+  config: {
+    relay: { name: "Test Relay" },
+  },
+  driveConfig: {
+    dataDir: "/tmp/test-data",
+  },
+}));
+
+vi.mock("../middleware/admin-auth", () => ({
+  adminAuthMiddleware: vi.fn((req, res, next) => {
+    if (req.headers.authorization === "Bearer valid-token") {
+      return next();
+    }
+    return res.status(401).json({ error: "Unauthorized" });
+  }),
+}));
+
+vi.mock("fs", () => {
+  return {
+    default: {
+      existsSync: vi.fn().mockReturnValue(true),
+      promises: {
+        stat: vi.fn().mockResolvedValue({ size: 100 }),
+        open: vi.fn().mockResolvedValue({
+          read: vi.fn().mockResolvedValue({ bytesRead: 15 }),
+          close: vi.fn().mockResolvedValue(undefined),
+        }),
+        access: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    constants: {
+      R_OK: 4,
+    },
+  };
+});
+
+describe("Service Logs Path Traversal Security", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+
+    // Mock gun instance for the router
+    app.set("gunInstance", {
+      _: { opt: { peers: {} } },
+      get: vi.fn().mockReturnThis(),
+      put: vi.fn().mockImplementation((val, cb) => cb({ err: null })),
+      once: vi.fn().mockImplementation((cb) => cb({ test: "data" })),
+    });
+
+    app.use("/api/v1/system", systemRouter);
+  });
+
+  it("should allow safe service names", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/ipfs/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it("should reject path traversal with '..'", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/../../etc/passwd/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid service name");
+  });
+
+  it("should reject path traversal with '/'", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/%2fetc%2fpasswd/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid service name");
+  });
+
+  it("should reject path traversal with '\\'", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/..%5c..%5cwindows/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid service name");
+  });
+
+  it("should reject potentially dangerous characters like null bytes", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/ipfs%00/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    // Currently this might not be rejected by the simple string inclusion checks
+    // We want our fix to reject this.
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid service name");
+  });
+
+  it("should reject other shell metacharacters", async () => {
+    const response = await request(app)
+      .get("/api/v1/system/services/ipfs;ls/logs")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid service name");
+  });
+});


### PR DESCRIPTION
Replaced loose string-based validation with strict whitelist-based regular expression validation for service names in the logs endpoint. This prevents path traversal and other potential injection attacks.

Modified:
- relay/src/routes/system.ts: implemented strict regex validation for `serviceName`

Added:
- relay/src/tests/service-logs-security.test.ts: security tests for the logs endpoint