### PR TITLE
chore: cleanup console.logs in debug config exposure tests

### DIFF
--- a/relay/src/tests/debug-config-exposure.test.ts
+++ b/relay/src/tests/debug-config-exposure.test.ts
@@ -77,8 +77,5 @@ describe("Debug Config Exposure Vulnerability", () => {
 
     // New field should be present
     expect(response.body.adminPasswordStatus).toBe("CONFIGURED");
-
-    console.log("Fix verified: No sensitive data exposed even with authentication");
-    console.log("Data:", JSON.stringify(response.body, null, 2));
   });
 });


### PR DESCRIPTION
Removed unnecessary console.log statements from relay/src/tests/debug-config-exposure.test.ts to make test output cleaner and reduce noise.